### PR TITLE
chore/ci: Optimize CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,24 @@
-language: java
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-cache:
-  directories:
-    - $HOME/android-sdk-dl
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-    - $HOME/.android/build-cache
 env:
   global:
-    - ANDROID_HOME=$HOME/.android
     - secure: vpb8bouCdr1JyG2pRncbwjqh5NIAbShq9DWxS2LmdqBh0c4/BIZNpjUoifwr10zZFHb6134dTnFvcfHS8rARGODUijrvUzN4pt1zHYku2VNI/70xmI/tiqZc17RIyEFNZypfeogug8cs47Vck5u0ce32vsfYLMk/Uqn7oy3tMzAp/Rkg54hlbaersRo7YBxqrcoJrNiMi9Ri7L3qVgQd01WZQgGHT/M2ffV6bg7QgAZg2ZimQz0Ila3qjLnB07c3dv0iIDvXO5bQCcNfI7Rh3qGtjeXmrWMLSn12CanBEzE1FmgCk86/SasFx/P6nZScHvfj2ilNv8T5M0kl2UMdANIbgpdKD5Ft+1NGUR+bSxdv1o+NEhIHpKwPECMpQ5zKucTIC5MThFt2k4o7U2472eentSNPmPyN6J47eTxfqL8g1TR4ZnICL5cIzipASgsk3/HTaNSWPHJs7sRmGltMTorbp/hkcmZ6LrT+Vqy0RvWKzxeS4aaTUZ9X973DLKOorgBF78tEj6Upqm3u0q1A6ZsBuOygxVLxdqic5rDP51Ay+f+erFR1H42IOZeZKE/RCzmCDnAkaPWeXVhnJklLreSqB0ll+c3mg/47f1Hv1r0DLUhEUpeaJAILFK3R8ZBF12mrlj8QI6WBKJXWYDEsMCvyPgosp23INnWdNIUMTBw=
 matrix:
   include:
     - os: linux
       jdk: oraclejdk8
-      install:
-        - if test ! -e $HOME/android-sdk-dl/sdk-tools.zip ; then curl --create-dirs https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -o $HOME/android-sdk-dl/sdk-tools.zip ; fi
-        - unzip -qq -n $HOME/android-sdk-dl/sdk-tools.zip -d $ANDROID_HOME
-        - echo y | $ANDROID_HOME/tools/bin/sdkmanager 'tools' > /dev/null
-        - echo y | $ANDROID_HOME/tools/bin/sdkmanager 'platform-tools' > /dev/null
-        - echo y | $ANDROID_HOME/tools/bin/sdkmanager 'emulator' > /dev/null
-        - echo y | $ANDROID_HOME/tools/bin/sdkmanager 'platforms;android-26' > /dev/null
-        - echo y | $ANDROID_HOME/tools/bin/sdkmanager 'system-images;android-24;default;armeabi-v7a' > /dev/null
+      language: android
+      android:
+        components:
+          - build-tools-28.0.3
+          - android-26
+          - android-24
+          - sys-img-armeabi-v7a-android-24
       before_script:
-        - echo no | $ANDROID_HOME/tools/bin/avdmanager create avd --force -n test  -k 'system-images;android-24;default;armeabi-v7a' > /dev/null
-        - curl https://gist.githubusercontent.com/lionel1704/c696119831cfda3b2c63ce8916ba21ef/raw/7c60e9e10e8abcb275361685d721be986d1be3e6/android-wait-for-emulator > android-wait-for-emulator
-        - $ANDROID_HOME/tools/emulator -avd test -no-window -no-audio &
-        - chmod +x ./android-wait-for-emulator
-        - ./android-wait-for-emulator
-        - $ANDROID_HOME/platform_tools/adb shell input keyevent 82 &
+        - echo no | android create avd --force -n test -t android-24 --abi armeabi-v7a -c 100M
+        - emulator -avd test -no-window &
+        - android-wait-for-emulator
+        - adb shell input keyevent 82 &
+        - echo ", ':safe-app-android'" >> settings.gradle
+        - ./gradlew :safe-app-android:download-nativelibs
       before_deploy:
         - ./gradlew :safe-app-android:javadoc
       deploy:
@@ -41,17 +29,13 @@ matrix:
         on:
           branch: master
     - os: osx
+      language: java
       osx_image: xcode10.1
   allow_failures:
     - os: osx
 before_install:
   - chmod +x gradlew
-  - mkdir -p $HOME/.android
-  - mkdir -p $ANDROID_HOME/licenses
-  - echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > $ANDROID_HOME/licenses/android-sdk-license
-  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> $ANDROID_HOME/licenses/android-sdk-license
 script:
-  - chmod +x gradlew
   - ./gradlew download-nativelibs
   - ./gradlew check
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./gradlew :safe-app-android:runInstrumentationTests; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,24 +1,11 @@
 image:
   - Previous Visual Studio 2015
 environment:
-  ANDROID_HOME: "C:\\android"
   JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
 clone_folder: "C:\\projects\\safe_app_java"
 init:
-  - mkdir "%ANDROID_HOME%
-  - cd "%ANDROID_HOME%"
-  - appveyor DownloadFile "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
-  - 7z x "tools_r25.2.3-windows.zip" > nul
   - cd "C:\projects\safe_app_java"
   - git config --global core.autocrlf true
-install:
-  - echo y | "%ANDROID_HOME%\tools\android.bat" --silent update sdk --no-ui --all --filter platform-tools,tools,build-tools-26.0.2,android-26,extra-google-m2repository,extra-android-m2repository
-  # on windows we need to accept sublicenses for the new tooling, wee. 30 is an arbitrary number,
-  # but should be the maximum number of licenses we explicitly need to type "Y ENTER" for.
-  # also, the sdkmanager in all its glory leaks a bit of output to stderr, and powershell
-  # and appveyor interpret that as errors, and blows up. so, when piping in our "Y ENTER"
-  # responses, we invoke cmd so we can redirect stderr to stdout, and tell it to --update itself.
-  - ps: for($i=0;$i -lt 30;$i++) { $response += "y`n"}; $response | cmd /c 'C:\android\tools\bin\sdkmanager.bat 2>&1' --update
 build: off
 test_script:
   - gradlew.bat download-nativelibs

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':safe-app-android', ':safe-app', ':api', ':safe-authenticator', ':lib'
+include ':safe-app', ':api', ':safe-authenticator', ':lib'


### PR DESCRIPTION
- Avoid downloading Android SDKs on Windows and OSX
- Remove `safe-app-android` from the list of modules and add it dynamically only on linux
- Use Travis' in-built tools to download Android SDKs